### PR TITLE
Fix memory leaks in WebSocket receive handler

### DIFF
--- a/main.c
+++ b/main.c
@@ -124,15 +124,8 @@ static int callback_websocket(struct lws *wsi,
 
             lws_callback_on_writable(wsi);
             break;
-        case LWS_CALLBACK_RECEIVE: { // the funny part
-            // create a buffer to hold our response
-            // it has to have some pre and post padding. You don't need to care
-            // what comes there, lwss will do everything for you. For more info see
-            // https://github.com/warmcat/libwebsockets/blob/main/include/libwebsockets.h#L597
-            unsigned char *buf = (unsigned char*) malloc(LWS_SEND_BUFFER_PRE_PADDING + len +
-                                                         LWS_SEND_BUFFER_POST_PADDING);
-
-            // log what we received and what we're going to send as a response.
+        case LWS_CALLBACK_RECEIVE: {
+            // log what we received.
             // that disco syntax `%.*s` is used to print just a part of our buffer
             // http://stackoverflow.com/questions/5189071/print-part-of-char-array
             printf("received data: %.*s\n", (int)len, (char*)in);
@@ -177,6 +170,7 @@ static int callback_websocket(struct lws *wsi,
                 LeapSetTrackingMode(connectionHandle, eLeapTrackingMode_Desktop);
             }
 
+            free(answer);
             break;
         }
         case LWS_CALLBACK_SERVER_WRITEABLE: {


### PR DESCRIPTION
## Summary

- Remove unused send buffer allocation that leaked on every received WebSocket message
- Free the answer string buffer before exiting the receive handler

## Details

The `LWS_CALLBACK_RECEIVE` case in `callback_websocket` had two memory leaks that grew with every incoming WebSocket message:

1. `buf` (line 132) — A buffer was allocated following the standard `lws_write()` pattern (with `LWS_SEND_BUFFER_PRE_PADDING` / `LWS_SEND_BUFFER_POST_PADDING`), and the comments described it as "a buffer to hold our response." However, the response-sending code was never implemented — buf was never written to, never passed to `lws_write()`, and never freed. This was dead code.
2. `answer` (line 140) — A 32-byte buffer allocated for `strcmp` comparisons against incoming messages, but never freed before the break at the end of the case block.

## Verification

Tested on macOS using the `leaks` diagnostic tool against the running process, sending 10 WebSocket messages to /v6.json:

### Before fix:
20 leaks for 640 total leaked bytes.
20 leaks = 10 messages × 2 leaked allocations (both buf and answer are 32 bytes each on ARM64).

### After fix:
0 leaks for 0 total leaked bytes.